### PR TITLE
Fix .sh/.bat config inconsistencies and missing quote

### DIFF
--- a/DedicatedLobbyServer.bat
+++ b/DedicatedLobbyServer.bat
@@ -99,4 +99,4 @@ if exist iw4x-launcher.exe start /W iw4x-launcher.exe --update
 :://DONE!! WARNING! Don't mess with anything below this line. SEROUSLY!//
 ::///////////////////////////////////////////////////////////////////////
 
-start iw4x.exe -dedicated +set fs_game "%ModFolderName%" +set sv_lanonly "%LANMode%" +set net_port "%GamePort%" +exec %ServerFilename% +set logfile "%LogFile%" +set party_enable "1" +set playlistFilename "%PlaylistFilename%" +playlist "%playlistGameMode%"
+start iw4x.exe -dedicated +set fs_game "%ModFolderName%" +set sv_lanonly "%LANMode%" +set net_port "%GamePort%" +exec %ServerFilename% +set logfile "%LogFile%" +set party_enable "1" +set playlistFilename "%PlaylistFilename%" +playlist "%PlaylistGameMode%"

--- a/DedicatedLobbyServer.sh
+++ b/DedicatedLobbyServer.sh
@@ -21,12 +21,12 @@ LogFile=1
 ModFolderName=
 
 # The name of your edited Playlist from the "userraw" folder goes here (optional)
-PlaylistFilename=partyserver.cfg
+PlaylistFilename=myplaylists.info
 
-# Your edited server.cfg in the "userraw" folder goes here...
+# Your edited partyserver.cfg in the "userraw" folder goes here...
 # This is where you edit your hostname, rcon, inactivity, etc
 # (Optional)
-ServerFilename=serverlan.cfg
+ServerFilename=partyserver.cfg
 
 # Remove this if automatic updates on start should be disabled
 if [ -f iw4x-launcher ]; then

--- a/DedicatedLobbyServerLAN.bat
+++ b/DedicatedLobbyServerLAN.bat
@@ -99,4 +99,4 @@ if exist iw4x-launcher.exe start /W iw4x-launcher.exe --update
 :://DONE!! WARNING! Don't mess with anything below this line. SEROUSLY!//
 ::///////////////////////////////////////////////////////////////////////
 
-start iw4x.exe -dedicated +set fs_game "%ModFolderName%" +set sv_lanonly "%LANMode%" +set net_port "%GamePort%" +exec %ServerFilename% +set logfile "%LogFile%" +set party_enable "1" +set playlistFilename "%PlaylistFilename%" +playlist "%playlistGameMode%"
+start iw4x.exe -dedicated +set fs_game "%ModFolderName%" +set sv_lanonly "%LANMode%" +set net_port "%GamePort%" +exec %ServerFilename% +set logfile "%LogFile%" +set party_enable "1" +set playlistFilename "%PlaylistFilename%" +playlist "%PlaylistGameMode%"

--- a/DedicatedServer.sh
+++ b/DedicatedServer.sh
@@ -21,7 +21,7 @@ ModFolderName=
 # Your edited server.cfg in the "userraw" folder goes here...
 # This is where you edit your hostname, rcon, inactivity, etc
 # (Optional)
-ServerFilename=serverlan.cfg
+ServerFilename=server.cfg
 
 # Remove this if automatic updates on start should be disabled
 if [ -f iw4x-launcher ]; then

--- a/userraw/server.cfg
+++ b/userraw/server.cfg
@@ -309,7 +309,7 @@ set scr_sab_defusetime "5"                      // Time taken to defuse the bomb
 set scr_sab_hotpotato "0"                       // One bomb that the teams must fight over. One defending and one have to plant at the site.
 set scr_sab_numlives "0"                        // Number of lives per player per game.
 set scr_sab_planttime "2.5"                     // Time taken to plant the bomb.
-set scr_sab_playerrespawndelay "7.5             // Time before respawn.
+set scr_sab_playerrespawndelay "7.5"             // Time before respawn.
 set scr_sab_roundlimit "1"                      // Rounds per game.
 set scr_sab_roundswitch "1"                     // Rounds needed to be played before the teams switch sides.
 set scr_sab_waverespawndelay "0"                // Time delay for first respawn before the game.

--- a/userraw/serverlan.cfg
+++ b/userraw/serverlan.cfg
@@ -310,7 +310,7 @@ set scr_sab_defusetime "5"                      // Time taken to defuse the bomb
 set scr_sab_hotpotato "0"                       // One bomb that the teams must fight over. One defending and one have to plant at the site.
 set scr_sab_numlives "0"                        // Number of lives per player per game.
 set scr_sab_planttime "2.5"                     // Time taken to plant the bomb.
-set scr_sab_playerrespawndelay "7.5             // Time before respawn.
+set scr_sab_playerrespawndelay "7.5"             // Time before respawn.
 set scr_sab_roundlimit "1"                      // Rounds per game.
 set scr_sab_roundswitch "1"                     // Rounds needed to be played before the teams switch sides.
 set scr_sab_waverespawndelay "0"                // Time delay for first respawn before the game.


### PR DESCRIPTION
## Summary
- **DedicatedServer.sh**: Fixed `ServerFilename` from `serverlan.cfg` to `server.cfg` to match the .bat counterpart (the non-LAN dedicated server should use `server.cfg`, not `serverlan.cfg`)
- **DedicatedLobbyServer.sh**: Fixed `PlaylistFilename` from `partyserver.cfg` to `myplaylists.info` and `ServerFilename` from `serverlan.cfg` to `partyserver.cfg` to match the .bat counterpart. Also fixed the comment to reference `partyserver.cfg` instead of `server.cfg`
- **DedicatedLobbyServer.bat** & **DedicatedLobbyServerLAN.bat**: Fixed `%playlistGameMode%` to `%PlaylistGameMode%` to match the variable name defined with `set PlaylistGameMode=` (Windows batch is case-insensitive so this was not a runtime bug, but it's an inconsistency worth fixing)
- **server.cfg** & **serverlan.cfg**: Added missing closing quote on `scr_sab_playerrespawndelay "7.5` → `"7.5"`

## Test plan
- [ ] Verify DedicatedServer.sh launches with `server.cfg` (non-LAN config)
- [ ] Verify DedicatedLobbyServer.sh launches with `myplaylists.info` playlist and `partyserver.cfg` config
- [ ] Verify sabotage gamemode respawn delay works correctly with the fixed quoted value

🤖 Generated with [Claude Code](https://claude.com/claude-code)